### PR TITLE
Adding CloudTrail role, used to retrieve UTC for instance stop. Addin…

### DIFF
--- a/.github/workflows/on_merge.yml
+++ b/.github/workflows/on_merge.yml
@@ -64,3 +64,4 @@ jobs:
               LambdaCodeBucket=${{ secrets.S3_BUCKET_PROD }} \
               LambdaCodeKey=${{ secrets.S3_PATH_PROD }}/function.zip \
               CreateDynamo=false
+              CreateCloudTrailRole=false

--- a/infrastructure/cloudformation/lambda-ec2-shutdown.yml
+++ b/infrastructure/cloudformation/lambda-ec2-shutdown.yml
@@ -20,8 +20,14 @@ Parameters:
     AllowedValues: ["true", "false"]
     Default: "true"
 
+  CreateCloudTrailRole:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "true"
+
 Conditions:
   CreateDynamoCond: !Equals [!Ref CreateDynamo, "true"]
+  CreateCloudTrailRoleCond: !Equals [!Ref CreateCloudTrailRole, "true"]
 
 Resources:
 
@@ -127,4 +133,19 @@ Resources:
                 Resource:
                   - !GetAtt StoppedInstanceLoggingTable.Arn
                   - !Sub "${StoppedInstanceLoggingTable.Arn}/index/*"
+
+  LambdaReadCloudTrailRole:
+    Condition:  CreateCloudTrailRoleCond
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: Lambda_Read_CloudTrail
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal: { Service: lambda.amazonaws.com }
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/AWSCloudTrail_ReadOnlyAccess
   


### PR DESCRIPTION
…g correlated condition for 'on-merge' vs. 'on-pull-request'